### PR TITLE
fix typo in mime-type vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 ISS_IMAGE_ROUTE_PREFIX=api
 ISS_IMAGE_ROUTE_MIDDLEWARE="hub.auth"
-ISS_IMAGE_VALID_MINE_TYPE="image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf"
+ISS_IMAGE_VALID_MIME_TYPE="image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf"
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is the contents of the published config file:
 return [
 
     'validation' => [
-        'mine_type' => env('ISS_IMAGE_VALID_MINE_TYPE', 'image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf'),
+        'mime_type' => env('ISS_IMAGE_VALID_MIME_TYPE', 'image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf'),
     ],
 
     'route' => [
@@ -47,7 +47,7 @@ If you want to change any settings, do so through your .env file.
 ```dotenv
 ISS_IMAGE_ROUTE_PREFIX=api
 ISS_IMAGE_ROUTE_MIDDLEWARE="hub.auth"
-ISS_IMAGE_VALID_MINE_TYPE="image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf"
+ISS_IMAGE_VALID_MIME_TYPE="image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf"
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
@@ -112,12 +112,12 @@ class NewPostController extends Controller
     {
         #TODO: Your Logic.
         
-//        $issUpload = new IssUpload($uploadRequest->entity, ($uploadRequest->filename, $uploadRequest->mine_type);
+//        $issUpload = new IssUpload($uploadRequest->entity, ($uploadRequest->filename, $uploadRequest->mime_type);
         
         $issUpload = new IssUpload();
         $issUpload->setEntity($uploadRequest->entity);
         $issUpload->setFilename($uploadRequest->filename);
-        $issUpload->setMineType($uploadRequest->mine_type);
+        $issUpload->setMimeType($uploadRequest->mime_type);
 
         dd($issUpload->getUploadSource());
         

--- a/config/iss-upload.php
+++ b/config/iss-upload.php
@@ -2,7 +2,7 @@
 
 return [
     'validation' => [
-        'mine_type' => env('ISS_IMAGE_VALID_MINE_TYPE', 'image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf'),
+        'mime_type' => env('ISS_IMAGE_VALID_MIME_TYPE', 'image/jpeg,image/gif,image/bmp,image/tiff,image/png,application/pdf'),
     ],
 
     'route' => [

--- a/src/Http/Requests/UploadRequest.php
+++ b/src/Http/Requests/UploadRequest.php
@@ -11,7 +11,7 @@ use League\MimeTypeDetection\ExtensionMimeTypeDetector;
  *
  * @property-read string entity
  * @property-read string filename
- * @property-read string mine_type
+ * @property-read string mime_type
  */
 class UploadRequest extends FormRequest
 {
@@ -33,7 +33,7 @@ class UploadRequest extends FormRequest
     public function prepareForValidation(): void
     {
         $this->merge([
-            'mine_ype' => (new ExtensionMimeTypeDetector)->detectMimeTypeFromPath((string)$this->filename),
+            'mime_type' => (new ExtensionMimeTypeDetector)->detectMimeTypeFromPath((string)$this->filename),
         ]);
     }
 
@@ -45,7 +45,7 @@ class UploadRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'mine_ype' => 'in:' . config('iss-upload.validation.mine_type'),
+            'mime_type' => 'in:' . config('iss-upload.validation.mime_type'),
             'filename' => 'required',
             'entity' => 'required',
         ];

--- a/src/IssUpload.php
+++ b/src/IssUpload.php
@@ -18,13 +18,13 @@ class IssUpload implements IssUploadContract
      *
      * @param  null|string  $entity
      * @param  null|string  $filename
-     * @param  string|null  $mineType
+     * @param  string|null  $mimeType
      */
-    public function __construct(?string $entity = null, ?string $filename = null, ?string $mineType = null)
+    public function __construct(?string $entity = null, ?string $filename = null, ?string $mimeType = null)
     {
         $this->entity = $entity;
         $this->filename = $filename;
-        $this->mineType = $mineType;
+        $this->mimeType = $mimeType;
     }
 
     /**
@@ -42,7 +42,7 @@ class IssUpload implements IssUploadContract
             'ACL' => 'public-read',
             'Bucket' => $bucket,
             'Key' => $key,
-            'ContentType' => $this->mineType,
+            'ContentType' => $this->mimeType,
         ]);
 
         $response = (string)$client->createPresignedRequest($cmd, '+10 minutes')->getUri();

--- a/src/IssUploadContract.php
+++ b/src/IssUploadContract.php
@@ -29,9 +29,9 @@ interface IssUploadContract
     public function setFilename(?string $filename): IssUploadContract;
 
     /**
-     * @param  string|null  $mineType
+     * @param  string|null  $mimeType
      *
      * @return IssUploadContract
      */
-    public function setMineType(?string $mineType): IssUploadContract;
+    public function setMimeType(?string $mimeType): IssUploadContract;
 }

--- a/src/IssUploadServiceProvider.php
+++ b/src/IssUploadServiceProvider.php
@@ -19,7 +19,7 @@ class IssUploadServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $uploadRequest = new UploadRequest(request()->all());
-        $this->app->singleton(IssUploadContract::class, fn () => new IssUpload($uploadRequest->entity, $uploadRequest->filename, $uploadRequest->mine_type));
+        $this->app->singleton(IssUploadContract::class, fn () => new IssUpload($uploadRequest->entity, $uploadRequest->filename, $uploadRequest->mime_type));
     }
 
     /**

--- a/src/IssUploadTrait.php
+++ b/src/IssUploadTrait.php
@@ -22,7 +22,7 @@ trait IssUploadTrait
     /**
      * @var string|null
      */
-    protected ?string $mineType;
+    protected ?string $mimeType;
 
     /**
      * @param  string|null  $entity
@@ -49,13 +49,13 @@ trait IssUploadTrait
     }
 
     /**
-     * @param  string|null  $mineType
+     * @param  string|null  $mimeType
      *
      * @return IssUploadContract
      */
-    public function setMineType(?string $mineType): IssUploadContract
+    public function setMimeType(?string $mimeType): IssUploadContract
     {
-        $this->mineType = $mineType;
+        $this->mimeType = $mimeType;
 
         return $this;
     }


### PR DESCRIPTION
Just fixing typo in mime-type words.